### PR TITLE
Correct way of passing dynamic service id

### DIFF
--- a/src/ScayTrase/WebSmsBridge/Resources/config/websms.yml
+++ b/src/ScayTrase/WebSmsBridge/Resources/config/websms.yml
@@ -1,5 +1,5 @@
 parameters:
-  websms_bridge.connection.driver: @websms_bridge.driver.json
+  websms_bridge.connection.driver: websms_bridge.driver.json
   websms_bridge.connection.login: null
   websms_bridge.connection.secret: null
   websms_bridge.connection.mode: 0
@@ -14,7 +14,7 @@ services:
   websms_bridge.connection:
     class: ScayTrase\WebSMS\Connection\Connection
     arguments:
-    - %websms_bridge.connection.driver%
+    - @=parameter('websms_bridge.connection.driver')
     - %websms_bridge.connection.login%
     - %websms_bridge.connection.secret%
     - %websms_bridge.connection.mode%


### PR DESCRIPTION
It shows "You cannot dump a container with parameters that contain references to other services" error otherwise
